### PR TITLE
feat: 팀 해체하기 구현

### DIFF
--- a/app/(tabs)/[teamId]/calendar/_layout.tsx
+++ b/app/(tabs)/[teamId]/calendar/_layout.tsx
@@ -4,8 +4,8 @@ import { useTeamSchedules } from "@/features/calendar/hooks/useSchedules";
 import { useTeamTodos } from "@/features/calendar/hooks/useTodos";
 import { SchedulesResponse } from "@/features/calendar/types/schedule.model";
 import { TodoResponse } from "@/features/calendar/types/todo.model";
-import { teamListUp } from "@/features/team/api/list";
-import { TeamDetail } from "@/features/team/types/team.model";
+import { useTeamDetail } from "@/features/team/hooks/useTeamDetail";
+import { useTeamList } from "@/features/team/hooks/useTeamList";
 import useCalendar from "@/shared/hooks/useCalendar";
 import { CalendarContext } from "@/shared/hooks/useCalendarAPI";
 import { CalendarSchedule } from "@/shared/types/Calendar";
@@ -13,11 +13,10 @@ import { globalGray700 } from "@/shared/ui";
 import NemoText from "@/shared/ui/atoms/NemoText";
 import Tabs, { TabsText } from "@/shared/ui/molecules/Tabs";
 import ModalEditableField from "@/shared/ui/organisms/ModalEditableField";
-import SideModal, { Teams } from "@/shared/ui/templates/SideModal";
+import SideModal from "@/shared/ui/templates/SideModal";
 import { Feather } from "@expo/vector-icons";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Slot, useLocalSearchParams, useRouter } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 const tabTexts: TabsText[] = [
@@ -117,15 +116,9 @@ export default function CalendarTodosScreen() {
   const calendarSchedules = convertSchedules(schedulesQuery.data);
   const calendarTodos = convertTodos(todosQuery.data);
 
-  const [info, setInfo] = useState<TeamDetail | null>(null);
-
-  useEffect(() => {
-    const fetchTeamInfo = async () => {
-      const teamInfo = await AsyncStorage.getItem("currentTeam");
-      setInfo(teamInfo ? JSON.parse(teamInfo) : null);
-    };
-    fetchTeamInfo();
-  }, [teamId]);
+  const { data: teamDetail } = useTeamDetail(
+    teamId ? parseInt(teamId as string) : null,
+  );
 
   const [selectedDate, setSelectedDate] = useState(today);
   const selectDate = useCallback((date: Date) => {
@@ -154,16 +147,7 @@ export default function CalendarTodosScreen() {
 
   const [isOpenSidebar, setIsOpenSidebar] = useState(false);
   // 사이드바 연동
-
-  const [teams, setTeams] = useState<Teams>([]);
-
-  useEffect(() => {
-    const initTeams = async () => {
-      const data = await teamListUp();
-      if (data) setTeams(data);
-    };
-    initTeams();
-  }, []);
+  const { data: teams = [] } = useTeamList();
 
   const handlePressTeamName = () => {
     setIsOpenSidebar(true);
@@ -191,7 +175,7 @@ export default function CalendarTodosScreen() {
           >
             <GroupIcon />
             <NemoText level="h3" style={{ marginLeft: 4 }}>
-              {info?.teamName}
+              {teamDetail?.teamName}
             </NemoText>
           </Pressable>
           <View style={{ margin: "auto" }} />
@@ -214,7 +198,7 @@ export default function CalendarTodosScreen() {
                 title="공지 작성"
                 description="팀에 공유할 공지 내용을 입력해주세요"
                 placeholder="아직 작성된 공지가 없어요"
-                defaultValue={info?.notice}
+                defaultValue={teamDetail?.notice}
               />
             </View>
             <Tabs texts={tabTexts} handler={handleTab} />

--- a/app/(tabs)/[teamId]/index.tsx
+++ b/app/(tabs)/[teamId]/index.tsx
@@ -1,5 +1,5 @@
 import { teamDetailInfo } from "@/features/team/api/detail";
-import { teamListUp } from "@/features/team/api/list";
+import { useTeamList } from "@/features/team/hooks/useTeamList";
 import { globalGray400, globalGray700, globalGray900 } from "@/shared/ui";
 import NemoText from "@/shared/ui/atoms/NemoText";
 import CtaButton from "@/shared/ui/molecules/CtaButton";
@@ -15,13 +15,13 @@ interface GroupScreenProps {}
 const GroupScreen = ({}: GroupScreenProps) => {
   const { teamId } = useLocalSearchParams();
   const route = useRouter();
+  const { data: teams } = useTeamList();
 
   useEffect(() => {
     const init = async () => {
       try {
         // teamId 없으면 팀 목록부터
         if (!teamId) {
-          const teams = await teamListUp();
           if (!teams || teams.length === 0) return;
 
           const firstTeam = teams[0];
@@ -45,7 +45,7 @@ const GroupScreen = ({}: GroupScreenProps) => {
     };
 
     init();
-  }, [teamId]);
+  }, [teamId, teams]);
 
   const handlePressStart = () => {
     route.navigate("/teams/check");

--- a/features/team/api/delete.ts
+++ b/features/team/api/delete.ts
@@ -1,0 +1,5 @@
+import { apiClient } from "@/shared/utils/http";
+
+export async function teamDisband(teamId: number) {
+  await apiClient.delete("/teams/" + teamId);
+}

--- a/features/team/components/TeamManagement.tsx
+++ b/features/team/components/TeamManagement.tsx
@@ -5,22 +5,37 @@ import { useAddPositionModal } from "@/features/position/hooks/useAddPositionMod
 import { PositionResponse } from "@/features/position/types/position.model";
 import { teamDetailInfo } from "@/features/team/api/detail";
 import { TeamDetail } from "@/features/team/types/team.model";
-import { globalGray700 } from "@/shared/ui";
+import { globalGray700, globalRed600 } from "@/shared/ui";
 import Chip from "@/shared/ui/atoms/Chip";
 import Input from "@/shared/ui/atoms/Input";
 import NemoText from "@/shared/ui/atoms/NemoText";
 import ProfileImage from "@/shared/ui/atoms/ProfileImage";
+import AlertModal from "@/shared/ui/organisms/AlertModal";
 import AddPositionModal from "@/shared/ui/templates/AddPositionModal";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import * as Clipboard from "expo-clipboard";
-import { ActivityIndicator, ScrollView, StyleSheet, View } from "react-native";
+import { router } from "expo-router";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+import { teamDisband } from "../api/delete";
+import { teamListUp } from "../api/list";
 
 interface TeamManagementProps {
   teamId: number | null;
 }
 
+type ActiveModal = { type: "disband" } | null;
+
 export default function TeamManagement({ teamId }: TeamManagementProps) {
   const { isVisible, open, close } = useAddPositionModal();
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null);
+  const queryClient = useQueryClient();
 
   // 팀 상세 정보 조회
   const {
@@ -53,6 +68,40 @@ export default function TeamManagement({ teamId }: TeamManagementProps) {
   const handleAddPosition = (positionName: string, colorHex: string) => {
     // TODO: 포지션 추가 API 연동
     console.log("포지션 추가:", positionName, colorHex);
+  };
+
+  const handleDisbandModalOpen = () => {
+    setActiveModal({ type: "disband" });
+  };
+
+  const handleDisbandModalClose = () => {
+    setActiveModal(null);
+  };
+
+  const handleDisbandTeam = async () => {
+    try {
+      await teamDisband(teamId!);
+      handleDisbandModalClose();
+
+      // 1. 서버에서 최신 팀 목록 다시 가져오기
+      const updatedTeams = await queryClient.fetchQuery({
+        queryKey: ["teamList"],
+        queryFn: teamListUp,
+      });
+
+      // 2. 남은 팀이 있는지 확인하여 이동
+      if (updatedTeams && updatedTeams.length > 0) {
+        // 해체한 팀이 아닌 다른 팀(첫 번째 팀)으로 이동
+        const nextTeam =
+          updatedTeams.find((t) => t.teamId !== teamId) || updatedTeams[0];
+        router.replace(`/(tabs)/${nextTeam.teamId}/calendar`);
+      } else {
+        // 팀이 하나도 없으면 명시적으로 팀이 없는 상태의 경로로 이동
+        router.replace("/(tabs)/home");
+      }
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   const isLoading = isLoadingTeam || isLoadingPositions;
@@ -144,6 +193,35 @@ export default function TeamManagement({ teamId }: TeamManagementProps) {
         </View>
       </ScrollView>
 
+      <View style={styles.footer}>
+        <Pressable onPress={handleDisbandModalOpen}>
+          <NemoText level="caption" style={{ color: globalRed600 }}>
+            팀 해체하기
+          </NemoText>
+        </Pressable>
+      </View>
+
+      <AlertModal
+        visible={activeModal !== null}
+        onClose={handleDisbandModalClose}
+      >
+        {activeModal && activeModal.type === "disband" && (
+          <>
+            <AlertModal.Title>팀 해체하기</AlertModal.Title>
+            <AlertModal.Text>
+              {`'${teamDetail.teamName}' 팀을 해체할까요?`}
+            </AlertModal.Text>
+            <AlertModal.Actions
+              type="double"
+              confirmLabel="해체하기"
+              onConfirm={handleDisbandTeam}
+              cancelLabel="취소하기"
+              onCancel={handleDisbandModalClose}
+            />
+          </>
+        )}
+      </AlertModal>
+
       <AddPositionModal
         visible={isVisible}
         closeModal={close}
@@ -180,5 +258,9 @@ const styles = StyleSheet.create({
   },
   inviteCodeContainer: {
     marginTop: 16,
+  },
+  footer: {
+    alignItems: "center",
+    paddingVertical: 20,
   },
 });

--- a/features/team/hooks/useTeamDetail.ts
+++ b/features/team/hooks/useTeamDetail.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { teamDetailInfo } from "../api/detail";
+
+export const useTeamDetail = (teamId: number | null) => {
+  return useQuery({
+    queryKey: ["teamDetail", teamId],
+    queryFn: () => teamDetailInfo(teamId!),
+    enabled: !!teamId,
+  });
+};

--- a/features/team/hooks/useTeamList.ts
+++ b/features/team/hooks/useTeamList.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { teamListUp } from "../api/list";
+
+export const useTeamList = () => {
+  return useQuery({
+    queryKey: ["teamList"],
+    queryFn: teamListUp,
+  });
+};

--- a/shared/ui/molecules/AlertModalInput.tsx
+++ b/shared/ui/molecules/AlertModalInput.tsx
@@ -8,7 +8,7 @@ interface AlertModalInputProps extends TextInputProps {
 
 const AlertModalInput = ({ ...props }: AlertModalInputProps) => {
   return (
-    <View>
+    <View style={{ width: "100%" }}>
       <Input variant="modal" {...props} />
     </View>
   );

--- a/shared/ui/templates/CalendarModal.tsx
+++ b/shared/ui/templates/CalendarModal.tsx
@@ -35,7 +35,7 @@ interface CalendarModalProps {
 
 export const reducer = (
   state: InitialCalendarState,
-  action: { type: string; payload: any }
+  action: { type: string; payload: any },
 ) => {
   switch (action.type) {
     case "SET_ISALLDAY":
@@ -91,14 +91,13 @@ const CalendarModal = ({
     },
   ];
   const [currentSegment, setCurrentSegment] = useState<"schedule" | "todo">(
-    type
+    type,
   );
 
   const [state, dispatch] = useReducer(reducer, initialState);
 
-
   const handleModalSegments = (
-    segment: { id: string; content: string; isActive: boolean }[]
+    segment: { id: string; content: string; isActive: boolean }[],
   ) => {
     const activeSegment = segment.find((s) => s.isActive);
     if (
@@ -154,6 +153,7 @@ const CalendarModal = ({
               <CalendarTodoForm />
             )}
           </CalendarFormContext.Provider>
+        </View>
         <View>
           <View style={style.container}>
             <View style={style.optionContainer}>


### PR DESCRIPTION
## **Description**

> 팀 해체하기 구현

## **More**

### fix: 팀 해체하기 시, 팀 네임 업데이트 안되는 문제 해결

이번 피알 올린거, 팀 해체하기 하고나서 다음 팀으로 캘린더 띄워졌을 때, 팀 네임이 업데이트 안되어 해체한 팀의 이름으로 표시된 문제가 있었어요. 기존에 스토리지에서 가져다 쓰는 형태여서, 팀 상세조회 api 호출한거에서 데이터 가져다가 띄우는 형태로 수정했습니다!

---

### fix: View 닫힌 태그 없는 부분 추가
‎shared/ui/templates/CalendarModal.tsx

지현님 - ref: 캘린더 모달 전체적인 리팩토링 
PR 올리셨던거 머지시키고 댕겨와서 브랜치에서 시뮬레이터 실행하는데 

‎shared/ui/templates/CalendarModal.tsx 여기서 View 태그 안 닫힌 부분 오류나서 채워줬습니다.