### PR TITLE
ref: 프로필/팀 이미지 지연 표시 개선 및 팀 이미지 캐시 동기화

### DIFF
--- a/app/(tabs)/[teamId]/calendar/_layout.tsx
+++ b/app/(tabs)/[teamId]/calendar/_layout.tsx
@@ -20,8 +20,9 @@ import Tabs, { TabsText } from "@/shared/ui/molecules/Tabs";
 import ModalEditableField from "@/shared/ui/organisms/ModalEditableField";
 import SideModal from "@/shared/ui/templates/SideModal";
 import { Feather } from "@expo/vector-icons";
+import { Image as ExpoImage } from "expo-image";
 import { Slot, useLocalSearchParams, useRouter } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
@@ -64,12 +65,30 @@ const convertTodos = (data: TodoResponse[] | undefined): CalendarSchedule[] => {
 
 export default function CalendarTodosScreen() {
   const route = useRouter();
+  const prefetchedImageUrisRef = useRef<Set<string>>(new Set());
 
   const { teamId } = useLocalSearchParams();
+  const parsedTeamId = teamId ? parseInt(teamId as string, 10) : NaN;
   const [tabTexts, setTabTexts] = useState<TabsText[]>([
     { id: 0, content: "캘린더", isActive: true },
     { id: 1, content: "스케줄/투두", isActive: false },
   ]);
+
+  const prefetchImageUris = useCallback(
+    (uris: Array<string | null | undefined>) => {
+      const filteredUris = uris
+        .filter((uri): uri is string => !!uri)
+        .filter((uri) => !prefetchedImageUrisRef.current.has(uri));
+
+      filteredUris.forEach((uri) => {
+        prefetchedImageUrisRef.current.add(uri);
+        ExpoImage.prefetch(uri, "memory-disk").catch(() => {
+          prefetchedImageUrisRef.current.delete(uri);
+        });
+      });
+    },
+    [],
+  );
 
   useEffect(() => {
     // teamId 바뀌면 항상 첫 탭으로 초기화
@@ -105,7 +124,7 @@ export default function CalendarTodosScreen() {
     year,
     month,
   );
-  const schedulesQuery = useTeamSchedules(parseInt(teamId as string), {
+  const schedulesQuery = useTeamSchedules(parsedTeamId, {
     start: new Date(
       currentYearMonth.year,
       currentYearMonth.month - 1,
@@ -118,7 +137,7 @@ export default function CalendarTodosScreen() {
     ).toISOString(),
   });
 
-  const todosQuery = useTeamTodos(parseInt(teamId as string), {
+  const todosQuery = useTeamTodos(parsedTeamId, {
     start: new Date(
       currentYearMonth.year,
       currentYearMonth.month - 1,
@@ -135,7 +154,7 @@ export default function CalendarTodosScreen() {
   const calendarTodos = convertTodos(todosQuery.data);
 
   const { data: teamDetail } = useTeamDetail(
-    teamId ? parseInt(teamId as string) : null,
+    Number.isFinite(parsedTeamId) ? parsedTeamId : null,
   );
 
   const [selectedDate, setSelectedDate] = useState(today);
@@ -167,6 +186,13 @@ export default function CalendarTodosScreen() {
   // 사이드바 연동
   const { data: teams = [] } = useTeamList();
 
+  useEffect(() => {
+    prefetchImageUris([
+      teamDetail?.teamImageUrl,
+      ...teams.map((team) => team.teamImageUrl),
+    ]);
+  }, [prefetchImageUris, teamDetail?.teamImageUrl, teams]);
+
   const handlePressTeamName = () => {
     setIsOpenSidebar(true);
   };
@@ -178,7 +204,7 @@ export default function CalendarTodosScreen() {
     route.push(`/(team)/members?teamId=${teamId}`);
   };
 
-  const noticeQuery = useLatestNotice(parseInt(teamId as string));
+  const noticeQuery = useLatestNotice(parsedTeamId);
 
   const callNotice = useCallback(() => noticeQuery.refetch(), [noticeQuery]);
 
@@ -189,11 +215,13 @@ export default function CalendarTodosScreen() {
   }, [teamId, noticeQuery.data]);
   const { createNotice, updateNotice, deleteNotice } = useNoticeMutations();
   const handleConfirmNotice = (newNotice: string) => {
+    if (!Number.isFinite(parsedTeamId) || parsedTeamId <= 0) return;
+
     setNotice(newNotice);
     if (!noticeQuery.data)
       createNotice.mutate(
         {
-          teamId: parseInt(teamId as string),
+          teamId: parsedTeamId,
           body: { content: newNotice },
         },
         {
@@ -205,7 +233,7 @@ export default function CalendarTodosScreen() {
       if (newNotice.trim() == "") {
         deleteNotice.mutate(
           {
-            teamId: parseInt(teamId as string),
+            teamId: parsedTeamId,
             noticeId: noticeQuery.data.id,
           },
           {
@@ -216,7 +244,7 @@ export default function CalendarTodosScreen() {
       } else
         updateNotice.mutate(
           {
-            teamId: parseInt(teamId as string),
+            teamId: parsedTeamId,
             noticeId: noticeQuery.data.id,
             body: { content: newNotice },
           },

--- a/features/team/components/TeamManagement.tsx
+++ b/features/team/components/TeamManagement.tsx
@@ -12,7 +12,7 @@ import { useAddPositionModal } from "@/features/position/hooks/useAddPositionMod
 import { PositionResponse } from "@/features/position/types/position.model";
 import { teamDetailInfo } from "@/features/team/api/detail";
 import { uploadTeamImage } from "@/features/team/api/image";
-import { TeamDetail } from "@/features/team/types/team.model";
+import { TeamDetail, TeamList } from "@/features/team/types/team.model";
 import { globalGray700, globalRed600 } from "@/shared/ui";
 import Chip from "@/shared/ui/atoms/Chip";
 import Input from "@/shared/ui/atoms/Input";
@@ -272,10 +272,64 @@ export default function TeamManagement({ teamId }: TeamManagementProps) {
 
   const uploadTeamImageMutation = useMutation({
     mutationFn: (imageUri: string) => uploadTeamImage(teamId!, imageUri),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["teamDetail", teamId] });
+    onMutate: async (imageUri) => {
+      if (!teamId) return;
+
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: ["teamDetail", teamId] }),
+        queryClient.cancelQueries({ queryKey: ["teamList"] }),
+      ]);
+
+      const previousTeamDetail = queryClient.getQueryData<TeamDetail>([
+        "teamDetail",
+        teamId,
+      ]);
+      const previousTeamList =
+        queryClient.getQueryData<TeamList[]>(["teamList"]);
+
+      queryClient.setQueryData<TeamDetail | undefined>(
+        ["teamDetail", teamId],
+        (previous) =>
+          previous
+            ? {
+                ...previous,
+                teamImageUrl: imageUri,
+              }
+            : previous,
+      );
+
+      queryClient.setQueryData<TeamList[] | undefined>(["teamList"], (previous) =>
+        previous?.map((team) =>
+          team.teamId === teamId
+            ? {
+                ...team,
+                teamImageUrl: imageUri,
+              }
+            : team,
+        ),
+      );
+
+      return { previousTeamDetail, previousTeamList };
     },
-    onError: (e) => {
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["teamDetail", teamId] }),
+        queryClient.invalidateQueries({ queryKey: ["teamList"] }),
+      ]);
+    },
+    onError: (e, _variables, context) => {
+      if (!teamId) return;
+
+      if (context?.previousTeamDetail) {
+        queryClient.setQueryData(
+          ["teamDetail", teamId],
+          context.previousTeamDetail,
+        );
+      }
+
+      if (context?.previousTeamList) {
+        queryClient.setQueryData(["teamList"], context.previousTeamList);
+      }
       console.log(e);
     },
   });

--- a/features/team/hooks/useTeamDetail.ts
+++ b/features/team/hooks/useTeamDetail.ts
@@ -1,10 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { teamDetailInfo } from "../api/detail";
 
+const TEAM_DETAIL_QUERY_STALE_TIME = 1000 * 60 * 5;
+
 export const useTeamDetail = (teamId: number | null) => {
   return useQuery({
     queryKey: ["teamDetail", teamId],
     queryFn: () => teamDetailInfo(teamId!),
     enabled: !!teamId,
+    staleTime: TEAM_DETAIL_QUERY_STALE_TIME,
   });
 };

--- a/features/team/hooks/useTeamList.ts
+++ b/features/team/hooks/useTeamList.ts
@@ -1,9 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { teamListUp } from "../api/list";
 
+const TEAM_LIST_QUERY_STALE_TIME = 1000 * 60 * 5;
+
 export const useTeamList = () => {
   return useQuery({
     queryKey: ["teamList"],
     queryFn: teamListUp,
+    staleTime: TEAM_LIST_QUERY_STALE_TIME,
   });
 };

--- a/features/team/hooks/useTeamMembers.ts
+++ b/features/team/hooks/useTeamMembers.ts
@@ -11,6 +11,8 @@ import {
 } from "../api/members";
 import type { TeamMember, TeamMembersResponse } from "../types/team.model";
 
+const TEAM_MEMBERS_QUERY_STALE_TIME = 1000 * 60 * 5;
+
 export interface MemberChip extends TeamMember {
   isActive: boolean;
 }
@@ -29,6 +31,7 @@ export function useTeamMembers(teamId: number | null) {
     queryKey: ["teams", teamId, "members"],
     queryFn: () => getTeamMembers(teamId as number),
     enabled: isEnabled,
+    staleTime: TEAM_MEMBERS_QUERY_STALE_TIME,
   });
 }
 

--- a/features/users/hooks/useUser.ts
+++ b/features/users/hooks/useUser.ts
@@ -8,10 +8,13 @@ import {
 import { changeMyName, changeMyProfileImage, getMe } from "../api/user";
 import type { UserResponse } from "../types/user.model";
 
+const USER_QUERY_STALE_TIME = 1000 * 60 * 5;
+
 export function useUser() {
   return useQuery<UserResponse>({
     queryKey: ["me", "user"],
     queryFn: getMe,
+    staleTime: USER_QUERY_STALE_TIME,
   });
 }
 

--- a/shared/ui/atoms/ProfileImage.tsx
+++ b/shared/ui/atoms/ProfileImage.tsx
@@ -1,4 +1,6 @@
-import { Image, StyleSheet, View } from "react-native";
+import { Image } from "expo-image";
+import { useEffect, useState } from "react";
+import { StyleSheet, View } from "react-native";
 import UserIcon from "../../../assets/icons/user";
 
 interface ProfileImageProps {
@@ -7,16 +9,30 @@ interface ProfileImageProps {
 }
 
 const ProfileImage = ({ uri, size }: ProfileImageProps) => {
+  const [isLoaded, setIsLoaded] = useState(!uri);
+
+  useEffect(() => {
+    setIsLoaded(!uri);
+  }, [uri]);
+
   return (
     <View style={[styles.container, { width: size, height: size }]}>
-      {uri ? (
-        <Image
-          source={{ uri }}
-          style={[styles.image, { width: size, height: size }]}
-          resizeMode="cover"
-        />
-      ) : (
+      <View style={styles.fallback}>
         <UserIcon size={size} />
+      </View>
+      {uri && (
+        <Image
+          source={uri}
+          style={[
+            styles.image,
+            { width: size, height: size, opacity: isLoaded ? 1 : 0 },
+          ]}
+          contentFit="cover"
+          cachePolicy="memory-disk"
+          transition={120}
+          onLoadEnd={() => setIsLoaded(true)}
+          onError={() => setIsLoaded(false)}
+        />
       )}
     </View>
   );
@@ -24,11 +40,18 @@ const ProfileImage = ({ uri, size }: ProfileImageProps) => {
 
 const styles = StyleSheet.create({
   container: {
+    position: "relative",
     alignItems: "center",
     justifyContent: "center",
     overflow: "hidden",
   },
+  fallback: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   image: {
+    ...StyleSheet.absoluteFillObject,
     borderRadius: 9999,
   },
 });

--- a/shared/ui/templates/SideModal.tsx
+++ b/shared/ui/templates/SideModal.tsx
@@ -4,6 +4,7 @@ import { TeamList } from "@/features/team/types/team.model";
 import { useUser } from "@/features/users/hooks/useUser";
 import { Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import {
   FlatList,
@@ -32,10 +33,15 @@ interface SideModalProps {
 
 const SideModal = ({ teams, closeModal }: SideModalProps) => {
   const route = useRouter();
+  const queryClient = useQueryClient();
   const { data: user } = useUser();
 
   const handlePressTeam = (id: number) => async () => {
-    const teamInfo = await teamDetailInfo(id);
+    const teamInfo = await queryClient.fetchQuery({
+      queryKey: ["teamDetail", id],
+      queryFn: () => teamDetailInfo(id),
+      staleTime: 1000 * 60 * 5,
+    });
     await AsyncStorage.setItem("currentTeam", JSON.stringify(teamInfo));
     closeModal();
     route.push(`/(tabs)/${id}/calendar`);


### PR DESCRIPTION
## **Description**

#### 문제
프로필/팀 이미지가 화면 진입 후 한 박자 늦게 표시되고, 팀 관리에서 팀 이미지를 변경해도 사이드바에는 이전 이미지가 보이는 문제

#### 원인
이미지 URL API 응답과 실제 이미지 렌더링(디코딩/캐시) 타이밍이 달랐고, 팀 이미지 변경 시 teamList 캐시가 즉시 갱신되지 않았습니다.

#### 해결 방법
- ProfileImage를 expo-image 기반으로 전환
- memory-disk 캐시/프리페치 경로 적용으로 이미지 표시 지연 완화
- 팀 이미지 업로드 시 teamDetail + teamList 캐시를 낙관적 업데이트하고, 성공/실패 시 invalidate/rollback 처리